### PR TITLE
Make table overview more functional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Thumbs.db
 .env.*
 !.env.example
 !.env.test
+*/.svelte-kit
 
 # Vite
 vite.config.js.timestamp-*

--- a/frontend/src/lib/components/DataDisplay/TableDisplay.svelte
+++ b/frontend/src/lib/components/DataDisplay/TableDisplay.svelte
@@ -66,7 +66,7 @@
 						value={pair[1]}
 						{statusIndicator}
 						{statusColumns}
-						href={celllinks[i] ? celllinks[i][j] : ''}
+						href={celllinks?.[i]?.[j] || ''}
 					/>
 				{/each}
 			</TableBodyRow>

--- a/frontend/src/lib/components/DataDisplay/TableDisplay.svelte
+++ b/frontend/src/lib/components/DataDisplay/TableDisplay.svelte
@@ -1,7 +1,6 @@
 <script context="module">
 	export function filterItems(data, searchTerm, searchableColumns) {
 		// toString here for generality
-
 		return data.filter((item) =>
 			searchableColumns.some((column) => item[column]?.toString().includes(searchTerm))
 		);
@@ -28,29 +27,26 @@
 	}
 </script>
 
-<script>
-	// @ts-nocheck
-
+<script lang="ts">
 	import { TableBody, TableBodyRow, TableSearch } from 'flowbite-svelte';
 
 	import TableCell from '$lib/components/DataDisplay/TableElements/TableCell.svelte';
 	import TableHeader from '$lib/components/DataDisplay/TableElements/TableHeader.svelte';
 
 	// exported variables
-	export let data = [];
-	export let links = []; // separate datastructure because it is specific to the point in the fronted where it is used but is static once defined. data comes from the backend and is not knowable until it's fetched.
-	export let headerlinks = [];
+	export let data: object[] = [];
+	export let celllinks: object[] = []; // separate datastructure because it is specific to the point in the fronted where it is used but is static once defined. data comes from the backend and is not knowable until it's fetched.
+	export let headerlinks: string[] = [];
 	export let caption = '';
+	export let statusColumns: string[] = [];
+	export let searchableColumns: string[] = [];
 	const legendcaption = 'Meaning of indicators';
 
 	export let statusIndicator = {
-		good: 'bg-green-500',
-		bad: 'bg-red-500',
-		warn: 'bg-yellow-500'
+		good: 'bg-green',
+		bad: 'bg-red',
+		warn: 'bg-yellow'
 	};
-
-	export let statusColumns = [];
-	export let searchableColumns = [];
 
 	// reactive statements
 	let searchTerm = '';
@@ -59,8 +55,6 @@
 
 	// make the placeholdertext for the searchbar dynamic
 	const placeholderText = makePlaceholderText(data, searchableColumns);
-
-	console.log('links: ', links);
 </script>
 
 <TableSearch
@@ -71,15 +65,15 @@
 >
 	<TableHeader {caption} columns={Object.keys(data[0])} links={headerlinks} />
 	<TableBody tableBodyClass="divide-y">
-		{#each filteredItems as item, idx}
+		{#each filteredItems as item, i}
 			<TableBodyRow>
-				{#each Object.entries(item) as pair}
+				{#each Object.entries(item) as pair, j}
 					<TableCell
 						key={pair[0]}
 						value={pair[1]}
 						{statusIndicator}
 						{statusColumns}
-						href={links[idx][pair[0]]}
+						href={celllinks[i] ? celllinks[i][j] : ''}
 					/>
 				{/each}
 			</TableBodyRow>

--- a/frontend/src/lib/components/DataDisplay/TableDisplay.svelte
+++ b/frontend/src/lib/components/DataDisplay/TableDisplay.svelte
@@ -35,26 +35,19 @@
 
 	// exported variables
 	export let data: object[] = [];
-	export let celllinks: object[] = []; // separate datastructure because it is specific to the point in the fronted where it is used but is static once defined. data comes from the backend and is not knowable until it's fetched.
-	export let headerlinks: string[] = [];
+	export let celllinks: string[][] = []; // separate datastructure because it is specific to the point in the fronted where it is used but is static once defined.
 	export let caption = '';
 	export let statusColumns: string[] = [];
 	export let searchableColumns: string[] = [];
-	const legendcaption = 'Meaning of indicators';
-
-	export let statusIndicator = {
-		good: 'bg-green',
-		bad: 'bg-red',
-		warn: 'bg-yellow'
-	};
-
-	// reactive statements
-	let searchTerm = '';
-
-	$: filteredItems = filterItems(data, searchTerm, searchableColumns);
+	export let statusIndicator;
+	export let headerlinks: string[] = [];
 
 	// make the placeholdertext for the searchbar dynamic
 	const placeholderText = makePlaceholderText(data, searchableColumns);
+	let searchTerm = '';
+
+	// reactive statements
+	$: filteredItems = filterItems(data, searchTerm, searchableColumns);
 </script>
 
 <TableSearch
@@ -65,9 +58,9 @@
 >
 	<TableHeader {caption} columns={Object.keys(data[0])} links={headerlinks} />
 	<TableBody tableBodyClass="divide-y">
-		{#each filteredItems as item, i}
+		{#each filteredItems as row, i}
 			<TableBodyRow>
-				{#each Object.entries(item) as pair, j}
+				{#each Object.entries(row) as pair, j}
 					<TableCell
 						key={pair[0]}
 						value={pair[1]}

--- a/frontend/src/lib/components/DataDisplay/TableDisplay.svelte
+++ b/frontend/src/lib/components/DataDisplay/TableDisplay.svelte
@@ -39,6 +39,7 @@
 	// exported variables
 	export let data = [];
 	export let links = []; // separate datastructure because it is specific to the point in the fronted where it is used but is static once defined. data comes from the backend and is not knowable until it's fetched.
+	export let headerlinks = [];
 	export let caption = '';
 	const legendcaption = 'Meaning of indicators';
 
@@ -68,7 +69,7 @@
 	hoverable={true}
 	striped={true}
 >
-	<TableHeader {caption} columns={Object.keys(data[0])} links={filteredItems.map((item) => {})} />
+	<TableHeader {caption} columns={Object.keys(data[0])} links={headerlinks} />
 	<TableBody tableBodyClass="divide-y">
 		{#each filteredItems as item, idx}
 			<TableBodyRow>

--- a/frontend/src/lib/components/DataDisplay/TableDisplay.svelte
+++ b/frontend/src/lib/components/DataDisplay/TableDisplay.svelte
@@ -38,6 +38,7 @@
 
 	// exported variables
 	export let data = [];
+	export let links = []; // separate datastructure because it is specific to the point in the fronted where it is used but is static once defined. data comes from the backend and is not knowable until it's fetched.
 	export let caption = '';
 	const legendcaption = 'Meaning of indicators';
 
@@ -57,6 +58,8 @@
 
 	// make the placeholdertext for the searchbar dynamic
 	const placeholderText = makePlaceholderText(data, searchableColumns);
+
+	console.log('links: ', links);
 </script>
 
 <TableSearch
@@ -65,12 +68,18 @@
 	hoverable={true}
 	striped={true}
 >
-	<TableHeader {caption} columns={Object.keys(data[0])} />
+	<TableHeader {caption} columns={Object.keys(data[0])} links={filteredItems.map((item) => {})} />
 	<TableBody tableBodyClass="divide-y">
-		{#each filteredItems as item}
+		{#each filteredItems as item, idx}
 			<TableBodyRow>
 				{#each Object.entries(item) as pair}
-					<TableCell key={pair[0]} value={pair[1]} {statusIndicator} {statusColumns} />
+					<TableCell
+						key={pair[0]}
+						value={pair[1]}
+						{statusIndicator}
+						{statusColumns}
+						href={links[idx][pair[0]]}
+					/>
 				{/each}
 			</TableBodyRow>
 		{/each}

--- a/frontend/src/lib/components/DataDisplay/TableElements/TableCell.svelte
+++ b/frontend/src/lib/components/DataDisplay/TableElements/TableCell.svelte
@@ -9,7 +9,7 @@
 </script>
 
 {#if statusColumns.includes(key)}
-	<TableBodyCell class={statusIndicator[value]}>
+	<TableBodyCell class={'hover:opacity-80 ' + statusIndicator[value]}>
 		{#if href !== ''}
 			<a {href}>{value}</a>
 		{:else}
@@ -17,7 +17,7 @@
 		{/if}
 	</TableBodyCell>
 {:else}
-	<TableBodyCell>
+	<TableBodyCell class="hover:opacity-80">
 		{#if href !== ''}
 			<a {href}>{value}</a>
 		{:else}

--- a/frontend/src/lib/components/DataDisplay/TableElements/TableCell.svelte
+++ b/frontend/src/lib/components/DataDisplay/TableElements/TableCell.svelte
@@ -1,14 +1,15 @@
-<script>
+<script lang="ts">
 	import { TableBodyCell } from 'flowbite-svelte';
 
 	export let value;
 	export let statusIndicator;
 	export let statusColumns;
 	export let key;
+	export let href: string = null;
 </script>
 
 {#if statusColumns.includes(key)}
-	<TableBodyCell class={statusIndicator[value]}>{value}</TableBodyCell>
+	<TableBodyCell class={statusIndicator[value]}><a {href}>{value}</a></TableBodyCell>
 {:else}
-	<TableBodyCell>{value}</TableBodyCell>
+	<TableBodyCell><a {href}>{value}</a></TableBodyCell>
 {/if}

--- a/frontend/src/lib/components/DataDisplay/TableElements/TableCell.svelte
+++ b/frontend/src/lib/components/DataDisplay/TableElements/TableCell.svelte
@@ -5,11 +5,23 @@
 	export let statusIndicator;
 	export let statusColumns;
 	export let key;
-	export let href: string = null;
+	export let href: string = '';
 </script>
 
 {#if statusColumns.includes(key)}
-	<TableBodyCell class={statusIndicator[value]}><a {href}>{value}</a></TableBodyCell>
+	<TableBodyCell class={statusIndicator[value]}>
+		{#if href !== ''}
+			<a {href}>{value}</a>
+		{:else}
+			{value}
+		{/if}
+	</TableBodyCell>
 {:else}
-	<TableBodyCell><a {href}>{value}</a></TableBodyCell>
+	<TableBodyCell>
+		{#if href !== ''}
+			<a {href}>{value}</a>
+		{:else}
+			{value}
+		{/if}
+	</TableBodyCell>
 {/if}

--- a/frontend/src/lib/components/DataDisplay/TableElements/TableHeader.svelte
+++ b/frontend/src/lib/components/DataDisplay/TableElements/TableHeader.svelte
@@ -1,8 +1,9 @@
-<script>
+<script lang="ts">
 	import { TableHead, TableHeadCell } from 'flowbite-svelte';
 
-	export let caption;
-	export let columns;
+	export let caption: string;
+	export let columns: string[];
+	export let links: string[];
 </script>
 
 <caption class="mb-4 font-normal leading-tight text-gray-700 dark:text-gray-400">
@@ -10,6 +11,12 @@
 </caption>
 <TableHead>
 	{#each columns as key, i}
-		<TableHeadCell>{key}</TableHeadCell>
+		<TableHeadCell>
+			{#if links[i]}
+				<a href={links[i]}>{key}</a>
+			{:else}
+				{key}
+			{/if}
+		</TableHeadCell>
 	{/each}
 </TableHead>

--- a/frontend/src/lib/stores/contentStore.ts
+++ b/frontend/src/lib/stores/contentStore.ts
@@ -129,6 +129,30 @@ async function createDummyData() {
 			],
 			last: 'surveyC',
 			next: null
+		},
+		surveyE: {
+			description: 'This is another survey called E',
+			milestones: [
+				{
+					name: 'Solving a shape-sorting toy',
+					items: ['not at all', 'to some extend', 'mostly', 'reliably'],
+					label: 'How well can the child solve a shape-sorting toy'
+				},
+				{
+					name: 'Counting to 10',
+					items: ['not at all', 'to some extend', 'mostly', 'reliably'],
+					label:
+						'How well can the child count to 10 and how well does it understand numbers within that range'
+				},
+				{
+					name: 'Counting to 20',
+					items: ['not at all', 'to some extend', 'mostly', 'reliably'],
+					label:
+						'How well can the child count to 20 and how well does it understand numbers within that range'
+				}
+			],
+			last: 'surveyC',
+			next: null
 		}
 	};
 

--- a/frontend/src/routes/childLand/[userID]/[childID]/+page.js
+++ b/frontend/src/routes/childLand/[userID]/[childID]/+page.js
@@ -3,9 +3,7 @@ import { error } from '@sveltejs/kit';
 
 /** @type {import('./$types').PageLoad}     */
 export async function load({ params }) {
-
-	children.load();
-
+	await children.load();
 	const observationData = await children.fetchObservationData(params.userID, params.childID);
 	const childData = await children.fetchChildData(params.userID, params.childID);
 

--- a/frontend/src/routes/childLand/[userID]/[childID]/+page.svelte
+++ b/frontend/src/routes/childLand/[userID]/[childID]/+page.svelte
@@ -3,39 +3,42 @@
 
 	// this will be passed from the backend eventually
 	export let data_to_display = $$props.data.observationData.summary;
-
 	// process data to add links: This could be done in the backend or stored accordingly
 	// this should not live in the data_to_display datastructure that will be obtained from the backend
-	const links = data_to_display.map((element) => {
-		let link = {};
+	const celllinks = data_to_display.map((element) => {
+		let link = [];
 		for (let date of Object.keys(element).filter((e) => e != 'name')) {
-			link[date] = '/surveyfeedback'; // FIXME: this is missing a date element: it should go /dataAcquisition/*date*/element.name
+			link.push('/milestone'); // TODO: this currently only links to a dummy milestone page
 		}
 		return link;
 	});
 
-	const headerlinks = data_to_display.map((element) => {
-		console.log(element['date']);
-		return { [element['date']]: '/surveyfeedback' };
+	const headerlinks = Object.keys(data_to_display[0]).map((k) => {
+		if (k === 'name') {
+			return null;
+		} else {
+			return '/surveyfeedback'; // TODO: this would lead to a page where the actual data is loaded for the survey
+		}
 	});
+
+	const statusColumns = Object.keys(data_to_display[0]).filter((key) => key !== 'name');
 
 	const statusIndicator = {
 		good: 'bg-green-500',
 		bad: 'bg-red-600',
 		warn: 'bg-yellow-300'
 	};
+
 	const searchableColumns = Object.keys(data_to_display[0]).filter((key) => key !== 'name');
 
 	const caption =
 		'Here you see an overview of all completed and outstanding milestones for the current inventory.';
-
-	const statusColumns = Object.keys(data_to_display[0]).filter((key) => key !== 'name');
 </script>
 
 <TableDisplay
 	{caption}
 	data={data_to_display}
-	{links}
+	{celllinks}
 	{headerlinks}
 	{statusIndicator}
 	{searchableColumns}

--- a/frontend/src/routes/childLand/[userID]/[childID]/+page.svelte
+++ b/frontend/src/routes/childLand/[userID]/[childID]/+page.svelte
@@ -1,10 +1,22 @@
 <script>
-	import { base } from '$app/paths';
-	import AbstractContent from '$lib/components/AbstractContent.svelte';
 	import TableDisplay from '$lib/components/DataDisplay/TableDisplay.svelte';
 
 	// this will be passed from the backend eventually
 	export let data_to_display = $$props.data.observationData.summary;
+
+	// process data to add links: This could be done in the backend or stored accordingly
+	const links = data_to_display.map((element) => {
+		let link = {};
+		link['name'] = '/';
+		for (let date of Object.keys(element).filter((e) => e != 'name')) {
+			link[date] = '/dataAcquisition/surveyA';
+		}
+		return link;
+	});
+
+	const headerlinks = data_to_display.map((element) => {
+		return {element.}
+	});
 
 	const statusIndicator = {
 		good: 'bg-green-500',
@@ -19,16 +31,11 @@
 	const statusColumns = Object.keys(data_to_display[0]).filter((key) => key !== 'name');
 </script>
 
-<AbstractContent
-	lastpage="/childrengallery"
-	nextpage={`${base}/dataAcquisition/${'surveyA'}`}
-	infopage="{base}/info"
->
-	<TableDisplay
-		{caption}
-		data={data_to_display}
-		{statusIndicator}
-		{searchableColumns}
-		{statusColumns}
-	/>
-</AbstractContent>
+<TableDisplay
+	{caption}
+	data={data_to_display}
+	{links}
+	{statusIndicator}
+	{searchableColumns}
+	{statusColumns}
+/>

--- a/frontend/src/routes/childLand/[userID]/[childID]/+page.svelte
+++ b/frontend/src/routes/childLand/[userID]/[childID]/+page.svelte
@@ -1,23 +1,28 @@
 <script lang="ts">
+	import { base } from '$app/paths';
 	import TableDisplay from '$lib/components/DataDisplay/TableDisplay.svelte';
+	import { children } from '$lib/stores/childrenStore';
+	import { onMount } from 'svelte';
 
 	// this will be passed from the backend eventually
 	export let data_to_display = $$props.data.observationData.summary;
 	// process data to add links: This could be done in the backend or stored accordingly
 	// this should not live in the data_to_display datastructure that will be obtained from the backend
 	const celllinks = data_to_display.map((element) => {
-		let link = [];
-		for (let date of Object.keys(element).filter((e) => e != 'name')) {
-			link.push('/milestone'); // TODO: this currently only links to a dummy milestone page
-		}
-		return link;
+		return Object.keys(element).map((k) => {
+			if (k === 'name') {
+				return null;
+			} else {
+				return `${base}/milestone`; // TODO: this would lead to a page where the actual data is loaded for the survey
+			}
+		});
 	});
 
 	const headerlinks = Object.keys(data_to_display[0]).map((k) => {
 		if (k === 'name') {
 			return null;
 		} else {
-			return '/surveyfeedback'; // TODO: this would lead to a page where the actual data is loaded for the survey
+			return `${base}/surveyfeedback`; // TODO: this would lead to a page where the actual data is loaded for the survey
 		}
 	});
 
@@ -33,6 +38,10 @@
 
 	const caption =
 		'Here you see an overview of all completed and outstanding milestones for the current inventory.';
+
+	onMount(() => {
+		children.load();
+	});
 </script>
 
 <TableDisplay

--- a/frontend/src/routes/childLand/[userID]/[childID]/+page.svelte
+++ b/frontend/src/routes/childLand/[userID]/[childID]/+page.svelte
@@ -1,21 +1,22 @@
-<script>
+<script lang="ts">
 	import TableDisplay from '$lib/components/DataDisplay/TableDisplay.svelte';
 
 	// this will be passed from the backend eventually
 	export let data_to_display = $$props.data.observationData.summary;
 
 	// process data to add links: This could be done in the backend or stored accordingly
+	// this should not live in the data_to_display datastructure that will be obtained from the backend
 	const links = data_to_display.map((element) => {
 		let link = {};
-		link['name'] = '/';
 		for (let date of Object.keys(element).filter((e) => e != 'name')) {
-			link[date] = '/dataAcquisition/surveyA';
+			link[date] = '/surveyfeedback'; // FIXME: this is missing a date element: it should go /dataAcquisition/*date*/element.name
 		}
 		return link;
 	});
 
 	const headerlinks = data_to_display.map((element) => {
-		return {element.}
+		console.log(element['date']);
+		return { [element['date']]: '/surveyfeedback' };
 	});
 
 	const statusIndicator = {
@@ -35,6 +36,7 @@
 	{caption}
 	data={data_to_display}
 	{links}
+	{headerlinks}
 	{statusIndicator}
 	{searchableColumns}
 	{statusColumns}

--- a/frontend/src/routes/dataAcquisition/[surveyName]/+page.js
+++ b/frontend/src/routes/dataAcquisition/[surveyName]/+page.js
@@ -3,11 +3,15 @@ import { error } from '@sveltejs/kit';
 
 /** @type {import('./$types').PageLoad}     */
 export async function load({ params }) {
-	createDummyData();
+	// README: temporary thing, this will be a backend call
+	const contentdata = await createDummyData();
+	content.set(contentdata);
 	const data = await content.fetch(params.surveyName);
+
 	if (!data) {
 		error(404, `Survey ${params.surveyName} not found`);
 	}
+
 	return {
 		surveyName: params.surveyName,
 		data: data

--- a/frontend/src/routes/dataAcquisition/[surveyName]/+page.svelte
+++ b/frontend/src/routes/dataAcquisition/[surveyName]/+page.svelte
@@ -22,7 +22,6 @@
 	// this should make sure that each time the page is rerouted to another instance of itself,
 	// the data is updated correctly and the new content is shown.
 	let x = null;
-	$: console.log($$props.data.data.next, $$props.data.data.last);
 	$: heading = $$props.data.surveyName;
 	$: description = $$props.data.data.description;
 	$: data_to_display = convertData($$props.data.data.milestones);

--- a/frontend/src/routes/surveyfeedback/+page.svelte
+++ b/frontend/src/routes/surveyfeedback/+page.svelte
@@ -31,6 +31,6 @@
 	{statusIndicator}
 	{caption}
 	{celllinks}
-	statusColumns="{['status']},"
+	statusColumns={['status']}
 	searchableColumns={['status']}
 />

--- a/frontend/src/routes/surveyfeedback/+page.svelte
+++ b/frontend/src/routes/surveyfeedback/+page.svelte
@@ -1,6 +1,4 @@
 <script>
-	import { base } from '$app/paths';
-	import AbstractContent from '$lib/components/AbstractContent.svelte';
 	import TableDisplay from '$lib/components/DataDisplay/TableDisplay.svelte';
 
 	const data_to_display = [
@@ -11,6 +9,11 @@
 		{ name: 'milestoneE', status: 'done' }
 	];
 
+	const celllinks = data_to_display.map((element) => {
+		let link = [null, '/milestone']; // TODO: this should lead to the respective survey itself
+		return link;
+	});
+
 	const statusIndicator = {
 		done: 'bg-green-500',
 		open: 'bg-red-600',
@@ -19,19 +22,15 @@
 
 	const caption =
 		'This is an overview over which milestones for the current survey have been completed';
+
+	console.log('celllinks in surveyfeedback', celllinks);
 </script>
 
-<AbstractContent
-	showBottomNavbar={true}
-	lastpage="{base}/dataAcquisition/surveyC"
-	nextpage="{base}"
-	infopage="{base}/info"
->
-	<TableDisplay
-		data={data_to_display}
-		{statusIndicator}
-		{caption}
-		statusColumns="{['status']},"
-		searchableColumns={['name']}
-	/>
-</AbstractContent>
+<TableDisplay
+	data={data_to_display}
+	{statusIndicator}
+	{caption}
+	{celllinks}
+	statusColumns="{['status']},"
+	searchableColumns={['status']}
+/>

--- a/frontend/src/routes/surveyfeedback/+page.svelte
+++ b/frontend/src/routes/surveyfeedback/+page.svelte
@@ -1,6 +1,6 @@
 <script>
+	import { base } from '$app/paths';
 	import TableDisplay from '$lib/components/DataDisplay/TableDisplay.svelte';
-
 	const data_to_display = [
 		{ name: 'milestoneA', status: 'done' },
 		{ name: 'milestoneB', status: 'open' },
@@ -10,7 +10,7 @@
 	];
 
 	const celllinks = data_to_display.map((element) => {
-		let link = [null, '/milestone']; // TODO: this should lead to the respective survey itself
+		let link = [null, `${base}/milestone`]; // TODO: this should lead to the respective survey itself
 		return link;
 	});
 
@@ -22,8 +22,6 @@
 
 	const caption =
 		'This is an overview over which milestones for the current survey have been completed';
-
-	console.log('celllinks in surveyfeedback', celllinks);
 </script>
 
 <TableDisplay


### PR DESCRIPTION
- add capability to have links to the `TableCell` component
- add dummy links to the existing tables: 
  - table cell with feedback: goes to milestone 
  - date in table header: goes to surveyfeedback
- several async function calls did not `await`. This has been fixed
- make `<script>` with changes blocks into typescript