### PR TITLE
Add overview page for individual milestone

### DIFF
--- a/frontend/src/lib/components/DataDisplay/CardDisplay.svelte
+++ b/frontend/src/lib/components/DataDisplay/CardDisplay.svelte
@@ -62,4 +62,11 @@
 			labelInsideClass={styleProps.progress?.labelInsideClass}
 		/>
 	{/if}
+
+	<!-- This will be generalized to replace button and progressbar later  -->
+	{#if data.auxilliary}
+		<div class="mb-4 mt-auto flex w-full justify-center">
+			<svelte:component this={data.auxilliary} {...styleProps.auxilliary} />
+		</div>
+	{/if}
 </Card>

--- a/frontend/src/lib/components/DataDisplay/CardDisplay.svelte
+++ b/frontend/src/lib/components/DataDisplay/CardDisplay.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { Button, Card, Progressbar } from 'flowbite-svelte';
+	import { Button, Card, Progressbar, Tooltip } from 'flowbite-svelte';
 	import { ArrowRightOutline } from 'flowbite-svelte-icons';
 	export let data = {
 		header: undefined,
@@ -24,8 +24,8 @@
 	imgClass="max-md:hidden object-scale-down"
 	href={data.button ? null : data.href}
 	class={data.button
-		? 'm-2 max-w-prose text-gray-700 dark:text-white'
-		: 'hover:transition-color m-2 max-w-prose cursor-pointer text-gray-700 hover:bg-gray-300 dark:text-white dark:hover:bg-gray-600 '}
+		? 'm-2 max-w-prose items-center  text-gray-700 dark:text-white'
+		: 'hover:transition-color m-2 max-w-prose cursor-pointer items-center text-gray-700 hover:bg-gray-300 dark:text-white dark:hover:bg-gray-600 '}
 	{...styleProps.card}
 >
 	{#if data.header}
@@ -40,8 +40,15 @@
 	{/if}
 	{#if data.button}
 		<Button href={data.href} class="w-fit" {...styleProps.button}
-			>{data.button} <ArrowRightOutline class="ms-2 h-6 w-6 text-white" /></Button
-		>
+			>{data.button}
+
+			{#if data.buttonIcon}
+				<svelte:component this={data.buttonIcon} class="ms-2 h-6 w-6 text-white" />
+			{:else}
+				<ArrowRightOutline class="ms-2 h-6 w-6 text-white" />
+			{/if}
+		</Button>
+		<Tooltip>Fortfahren</Tooltip>
 	{/if}
 
 	{#if data.progress}

--- a/frontend/src/lib/components/DataDisplay/GalleryDisplay.svelte
+++ b/frontend/src/lib/components/DataDisplay/GalleryDisplay.svelte
@@ -20,6 +20,12 @@
 	// dynamic statements
 	let searchTerm = '';
 	$: filteredItems = withSearch === true ? filterData(data, searchableCol, searchTerm) : data;
+
+	// Create a new array of componentProps that matches the filtered data
+	$: filteredComponentProps = filteredItems.map((item) => {
+		const index = data.indexOf(item);
+		return componentProps[index];
+	});
 </script>
 
 <div class="mx-auto p-4">
@@ -41,10 +47,14 @@
 	{/if}
 
 	<Gallery
-		class="grid w-full grid-cols-2 justify-center gap-8 p-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-4"
+		class="grid w-full grid-cols-1 justify-center gap-8 p-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
 	>
 		{#each filteredItems as item, index}
-			<svelte:component this={itemComponent} data={item} styleProps={componentProps[index]} />
+			<svelte:component
+				this={itemComponent}
+				data={item}
+				styleProps={filteredComponentProps[index]}
+			/>
 		{/each}
 	</Gallery>
 </div>

--- a/frontend/src/lib/components/DataDisplay/GalleryDisplay.svelte
+++ b/frontend/src/lib/components/DataDisplay/GalleryDisplay.svelte
@@ -1,15 +1,13 @@
-<script context="module">
-	export function filterDataByColumn(data, col, searchTerm) {
+<script lang="ts">
+	import { Gallery, Heading, Search } from 'flowbite-svelte';
+
+	export function filterData(data, col, searchTerm) {
 		if (searchTerm === '') {
 			return data;
 		} else {
 			return data.filter((item) => item[col].toLowerCase().includes(searchTerm.toLowerCase()));
 		}
 	}
-</script>
-
-<script lang="ts">
-	import { Gallery, Heading, Search } from 'flowbite-svelte';
 
 	export let data;
 	export let header: string | null = null;
@@ -17,14 +15,14 @@
 	export let withSearch = true;
 	export let searchableCol = '';
 	export let componentProps;
+	export let searchPlaceHolder = 'Durchsuchen';
 
 	// dynamic statements
 	let searchTerm = '';
-	$: filteredItems =
-		withSearch === true ? filterDataByColumn(data, searchableCol, searchTerm) : data;
+	$: filteredItems = withSearch === true ? filterData(data, searchableCol, searchTerm) : data;
 </script>
 
-<div class="mx-auto max-w-7xl p-4">
+<div class="mx-auto p-4">
 	{#if header !== null}
 		<Heading
 			tag="h1"
@@ -38,7 +36,7 @@
 
 	{#if withSearch}
 		<form class="m-2 mt-4 flex w-full gap-2 p-2">
-			<Search size="md" placeholder={'Durchsuchen'} bind:value={searchTerm} />
+			<Search size="md" placeholder={searchPlaceHolder} bind:value={searchTerm} />
 		</form>
 	{/if}
 

--- a/frontend/src/lib/components/DataDisplay/GalleryDisplay.svelte
+++ b/frontend/src/lib/components/DataDisplay/GalleryDisplay.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import { Gallery, Heading, Search } from 'flowbite-svelte';
 
-	export function filterData(data, col, searchTerm) {
+	export let filterData = (data, col, searchTerm) => {
 		if (searchTerm === '') {
 			return data;
 		} else {
 			return data.filter((item) => item[col].toLowerCase().includes(searchTerm.toLowerCase()));
 		}
-	}
+	};
 
 	export let data;
 	export let header: string | null = null;

--- a/frontend/src/lib/components/DataDisplay/GalleryDisplay.svelte
+++ b/frontend/src/lib/components/DataDisplay/GalleryDisplay.svelte
@@ -41,7 +41,7 @@
 	{/if}
 
 	<Gallery
-		class="grid w-full grid-cols-1 justify-center gap-8 p-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+		class="grid w-full grid-cols-2 justify-center gap-8 p-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-4"
 	>
 		{#each filteredItems as item, index}
 			<svelte:component this={itemComponent} data={item} styleProps={componentProps[index]} />

--- a/frontend/src/lib/components/DataDisplay/GalleryDisplay.svelte
+++ b/frontend/src/lib/components/DataDisplay/GalleryDisplay.svelte
@@ -35,7 +35,7 @@
 	{/if}
 
 	{#if withSearch}
-		<form class="m-2 mt-4 flex w-full gap-2 p-2">
+		<form class="m-2 w-full p-4">
 			<Search size="md" placeholder={searchPlaceHolder} bind:value={searchTerm} />
 		</form>
 	{/if}

--- a/frontend/src/lib/components/MilestoneGroup.svelte
+++ b/frontend/src/lib/components/MilestoneGroup.svelte
@@ -35,7 +35,6 @@
 			searchableCol={'header'}
 			componentProps={createStyle(milestonedata)}
 			withSearch={true}
-			header={'Bereichsübersicht'}
 		/>
 	</div>
 </div>

--- a/frontend/src/lib/components/MilestoneOverview.svelte
+++ b/frontend/src/lib/components/MilestoneOverview.svelte
@@ -77,7 +77,6 @@
 
 		<GalleryDisplay
 			data={rawdata}
-			desc={null}
 			itemComponent={CardDisplay}
 			componentProps={rawdata.map((item) => {
 				return {

--- a/frontend/src/lib/components/MilestoneOverview.svelte
+++ b/frontend/src/lib/components/MilestoneOverview.svelte
@@ -63,7 +63,7 @@
 			<Progressbar
 				labelInsideClass="h-6 rounded-full text-md text-center text-white"
 				size="h-6"
-				divClass={`h-full rounded-full w-${100 * progress}`}
+				divClass={`mb-2 mt-2 h-full rounded-full w-${100 * progress}`}
 				labelInside
 				color={progress === 1 ? 'green' : 'primary'}
 				progress={String(100 * progress)}

--- a/frontend/src/lib/components/MilestoneOverview.svelte
+++ b/frontend/src/lib/components/MilestoneOverview.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+	import { base } from '$app/paths';
+	import Breadcrumbs from '$lib/components/Breadcrumbs.svelte';
+	import CardDisplay from '$lib/components/DataDisplay/CardDisplay.svelte';
+	import GalleryDisplay from '$lib/components/DataDisplay/GalleryDisplay.svelte';
+	import { CheckCircleSolid, ExclamationCircleSolid } from 'flowbite-svelte-icons';
+
+	import { Heading, Progressbar, Search } from 'flowbite-svelte';
+
+	function filterData(data: object[], key: string): object[] {
+		if (key === '') {
+			return data;
+		} else {
+			return data.filter((item) => {
+				// button label contains info about completion status => use for search
+				return item.header.includes(key) || item.button.includes(key);
+			});
+		}
+	}
+
+	function sortData(data: object[]): object[] {
+		return data;
+	}
+
+	// FIXME: this must go eventually. Either must happen in the backend or there
+	// should be some other way to deal with it
+	function convertData(data: object[]): object[] {
+		return data.map((item) => {
+			return {
+				header: item.title,
+				summary: item.desc,
+				href: `${base}/milestone`, // hardcoded link for the moment
+				button: item.answer !== null ? 'Fertig' : 'Noch nicht beantwortet',
+				buttonIcon: item.answer !== null ? CheckCircleSolid : ExclamationCircleSolid
+			};
+		});
+	}
+
+	export let breadcrumbdata: object[] = [];
+	export let data: object[] = [];
+	export let searchTerm: string = '';
+	export let progress: number;
+	export let title: string;
+	export let desc: string;
+
+	const rawdata = convertData(data); // FIXME: this step should not be here
+	$: filteredItems = sortData(filterData(rawdata, searchTerm));
+</script>
+
+<div class="flex flex-col border border-gray-200 md:rounded-t-lg dark:border-gray-700">
+	<Breadcrumbs data={breadcrumbdata} />
+	<div class="grid gap-y-8 p-4">
+		<Heading
+			tag="h1"
+			class="m-1 mb-3 p-1 px-6 font-bold tracking-tight text-gray-700 dark:text-white"
+			>{title}</Heading
+		>
+		<p class="px-6 text-gray-700 dark:text-white">{desc}</p>
+		<div class="px-6">
+			<Progressbar
+				labelInsideClass="h-6 rounded-full text-md text-center text-white"
+				size="h-6"
+				divClass={`h-full rounded-full w-${100 * progress}`}
+				labelInside
+				color={progress === 1 ? 'green' : 'primary'}
+				progress={String(100 * progress)}
+				animate={true}
+			/>
+		</div>
+		<div class="px-6">
+			<Search
+				size="md"
+				placeholder={'Nach Status oder Titel durchsuchen'}
+				bind:value={searchTerm}
+			/>
+		</div>
+
+		<GalleryDisplay
+			data={filteredItems}
+			itemComponent={CardDisplay}
+			componentProps={filteredItems.map((item) => {
+				return {
+					card: {
+						class: 'm-2 max-w-prose dark:text-white text-gray-700 '
+					},
+					button: {
+						color: item.button === 'Fertig' ? 'green' : 'primary'
+					}
+				};
+			})}
+			withSearch={false}
+		/>
+	</div>
+</div>

--- a/frontend/src/lib/components/MilestoneOverview.svelte
+++ b/frontend/src/lib/components/MilestoneOverview.svelte
@@ -11,7 +11,13 @@
 		} else {
 			return data.filter((item) => {
 				// button label contains info about completion status => use for search
-				return item.header.toLowerCase().includes(key.toLowerCase());
+				if (key === completeKey) {
+					return item.complete === true;
+				} else if (key === incompleteKey) {
+					return item.complete === false;
+				} else {
+					return item.header.toLowerCase().includes(key.toLowerCase());
+				}
 			});
 		}
 	}
@@ -23,15 +29,17 @@
 			return {
 				header: item.title,
 				href: `${base}/milestone`, // hardcoded link for the moment
-				complete: item.answer === null,
+				complete: item.answer !== null,
 				auxilliary: item.answer !== null ? CheckCircleSolid : ExclamationCircleSolid
 			};
 		});
 	}
 
+	const completeKey = 'fertig';
+	const incompleteKey = 'unfertig';
 	export let breadcrumbdata: object[] = [];
 	export let data: object[] = [];
-	const rawdata = convertData(data); // FIXME: this step should not be here and will be handeled backend-side
+	const rawdata = convertData(data).sort((a, b) => a.complete - b.complete); // FIXME: the convert step should not be here and will be handeled backend-side
 </script>
 
 <div class="mx-auto flex flex-col border border-gray-200 p-4 md:rounded-t-lg dark:border-gray-700">
@@ -43,15 +51,16 @@
 			componentProps={rawdata.map((item) => {
 				return {
 					card: {
-						class: `${item.complete ? 'text-gray-700 hover:bg-gray-100 hover:bg-green' : 'text-white bg-primary-700 bg-opacity-100 hover:bg-green'}`
+						class: 'text-gray-700 hover:bg-gray-100'
 					},
 
 					auxilliary: {
-						class: 'w-14 h-14 '
+						class: 'w-14 h-14',
+						color: item.complete === true ? '#4ade80' : '#EB4F27'
 					}
 				};
 			})}
-			searchPlaceHolder={'Nach Status (Fertig/Noch nicht bearbeitet) oder Titel durchsuchen'}
+			searchPlaceHolder={`Nach Status (${completeKey}/${incompleteKey}) oder Titel durchsuchen`}
 			withSearch={true}
 			{filterData}
 		/>

--- a/frontend/src/lib/components/MilestoneOverview.svelte
+++ b/frontend/src/lib/components/MilestoneOverview.svelte
@@ -14,13 +14,12 @@
 		} else {
 			return data.filter((item) => {
 				// button label contains info about completion status => use for search
-				return item.header.includes(key) || item.button.toLowerCase().includes(key.toLowerCase());
+				return (
+					item.header.toLowerCase().includes(key.toLowerCase()) ||
+					item.button.toLowerCase().includes(key.toLowerCase())
+				);
 			});
 		}
-	}
-
-	function sortData(data: object[]): object[] {
-		return data;
 	}
 
 	// FIXME: this must go eventually. Either must happen in the backend or there
@@ -92,6 +91,7 @@
 			})}
 			searchPlaceHolder={'Nach Status (Fertig/Noch nicht bearbeitet) oder Titel durchsuchen'}
 			withSearch={true}
+			{filterData}
 		/>
 	</div>
 </div>

--- a/frontend/src/lib/components/MilestoneOverview.svelte
+++ b/frontend/src/lib/components/MilestoneOverview.svelte
@@ -3,10 +3,7 @@
 	import Breadcrumbs from '$lib/components/Breadcrumbs.svelte';
 	import CardDisplay from '$lib/components/DataDisplay/CardDisplay.svelte';
 	import GalleryDisplay from '$lib/components/DataDisplay/GalleryDisplay.svelte';
-	import { Hr } from 'flowbite-svelte';
 	import { CheckCircleSolid, ExclamationCircleSolid } from 'flowbite-svelte-icons';
-
-	import { Heading, Progressbar } from 'flowbite-svelte';
 
 	function filterData(data: object[], dummy: any, key: string): object[] {
 		if (key === '') {
@@ -14,77 +11,43 @@
 		} else {
 			return data.filter((item) => {
 				// button label contains info about completion status => use for search
-				return (
-					item.header.toLowerCase().includes(key.toLowerCase()) ||
-					item.button.toLowerCase().includes(key.toLowerCase())
-				);
+				return item.header.toLowerCase().includes(key.toLowerCase());
 			});
 		}
 	}
 
 	// FIXME: this must go eventually. Either must happen in the backend or there
-	// should be some other way to deal with it
+	// should be in a refactored version of the card component
 	function convertData(data: object[]): object[] {
 		return data.map((item) => {
 			return {
 				header: item.title,
-				summary: item.desc,
 				href: `${base}/milestone`, // hardcoded link for the moment
-				button: item.answer !== null ? 'Fertig' : 'Noch nicht beantwortet',
-				buttonIcon: item.answer !== null ? CheckCircleSolid : ExclamationCircleSolid
+				complete: item.answer === null,
+				auxilliary: item.answer !== null ? CheckCircleSolid : ExclamationCircleSolid
 			};
 		});
 	}
 
 	export let breadcrumbdata: object[] = [];
 	export let data: object[] = [];
-	export let progress: number;
-	export let title: string;
-	export let desc: string;
-
-	const rawdata = convertData(data); // FIXME: this step should not be here
+	const rawdata = convertData(data); // FIXME: this step should not be here and will be handeled backend-side
 </script>
 
 <div class="mx-auto flex flex-col border border-gray-200 p-4 md:rounded-t-lg dark:border-gray-700">
 	<Breadcrumbs data={breadcrumbdata} />
 	<div class="grid gap-y-4 p-4">
-		<Heading
-			tag="h1"
-			class="m-1 mb-3 p-1 px-6 font-bold tracking-tight text-gray-700 dark:text-white"
-			>{title}</Heading
-		>
-		<p class="px-6 text-gray-700 dark:text-white">{desc}</p>
-
-		<div class="px-6">
-			<div class="text-xl text-gray-700 dark:text-white">
-				<Hr classHr="my-8 w-full">Grad der Fertigstellung</Hr>
-			</div>
-
-			<Progressbar
-				labelInsideClass="h-6 rounded-full text-md text-center text-white"
-				size="h-6"
-				divClass={`mb-2 mt-2 h-full rounded-full w-${100 * progress}`}
-				labelInside
-				color={progress === 1 ? 'green' : 'primary'}
-				progress={String(100 * progress)}
-				animate={true}
-			/>
-		</div>
-
-		<div class="px-6 text-xl text-gray-700 dark:text-white">
-			<Hr classHr="my-8 w-full">Einzelne Meilensteine</Hr>
-		</div>
-
 		<GalleryDisplay
 			data={rawdata}
 			itemComponent={CardDisplay}
 			componentProps={rawdata.map((item) => {
 				return {
 					card: {
-						class: 'm-2 max-w-prose dark:text-white text-gray-700'
+						class: `${item.complete ? 'text-gray-700 hover:bg-gray-100 hover:bg-green' : 'text-white bg-primary-700 bg-opacity-100 hover:bg-green'}`
 					},
-					button: {
-						color: item.button === 'Fertig' ? 'green' : 'primary'
+
+					auxilliary: {
+						class: 'w-14 h-14 '
 					}
 				};
 			})}

--- a/frontend/src/lib/components/MilestoneOverview.svelte
+++ b/frontend/src/lib/components/MilestoneOverview.svelte
@@ -3,17 +3,18 @@
 	import Breadcrumbs from '$lib/components/Breadcrumbs.svelte';
 	import CardDisplay from '$lib/components/DataDisplay/CardDisplay.svelte';
 	import GalleryDisplay from '$lib/components/DataDisplay/GalleryDisplay.svelte';
+	import { Hr } from 'flowbite-svelte';
 	import { CheckCircleSolid, ExclamationCircleSolid } from 'flowbite-svelte-icons';
 
-	import { Heading, Progressbar, Search } from 'flowbite-svelte';
+	import { Heading, Progressbar } from 'flowbite-svelte';
 
-	function filterData(data: object[], key: string): object[] {
+	function filterData(data: object[], dummy: any, key: string): object[] {
 		if (key === '') {
 			return data;
 		} else {
 			return data.filter((item) => {
 				// button label contains info about completion status => use for search
-				return item.header.includes(key) || item.button.includes(key);
+				return item.header.includes(key) || item.button.toLowerCase().includes(key.toLowerCase());
 			});
 		}
 	}
@@ -38,25 +39,28 @@
 
 	export let breadcrumbdata: object[] = [];
 	export let data: object[] = [];
-	export let searchTerm: string = '';
 	export let progress: number;
 	export let title: string;
 	export let desc: string;
 
 	const rawdata = convertData(data); // FIXME: this step should not be here
-	$: filteredItems = sortData(filterData(rawdata, searchTerm));
 </script>
 
-<div class="flex flex-col border border-gray-200 md:rounded-t-lg dark:border-gray-700">
+<div class="mx-auto flex flex-col border border-gray-200 p-4 md:rounded-t-lg dark:border-gray-700">
 	<Breadcrumbs data={breadcrumbdata} />
-	<div class="grid gap-y-8 p-4">
+	<div class="grid gap-y-4 p-4">
 		<Heading
 			tag="h1"
 			class="m-1 mb-3 p-1 px-6 font-bold tracking-tight text-gray-700 dark:text-white"
 			>{title}</Heading
 		>
 		<p class="px-6 text-gray-700 dark:text-white">{desc}</p>
+
 		<div class="px-6">
+			<div class="text-xl text-gray-700 dark:text-white">
+				<Hr classHr="my-8 w-full">Grad der Fertigstellung</Hr>
+			</div>
+
 			<Progressbar
 				labelInsideClass="h-6 rounded-full text-md text-center text-white"
 				size="h-6"
@@ -67,28 +71,27 @@
 				animate={true}
 			/>
 		</div>
-		<div class="px-6">
-			<Search
-				size="md"
-				placeholder={'Nach Status oder Titel durchsuchen'}
-				bind:value={searchTerm}
-			/>
+
+		<div class="px-6 text-xl text-gray-700 dark:text-white">
+			<Hr classHr="my-8 w-full">Einzelne Meilensteine</Hr>
 		</div>
 
 		<GalleryDisplay
-			data={filteredItems}
+			data={rawdata}
+			desc={null}
 			itemComponent={CardDisplay}
-			componentProps={filteredItems.map((item) => {
+			componentProps={rawdata.map((item) => {
 				return {
 					card: {
-						class: 'm-2 max-w-prose dark:text-white text-gray-700 '
+						class: 'm-2 max-w-prose dark:text-white text-gray-700'
 					},
 					button: {
 						color: item.button === 'Fertig' ? 'green' : 'primary'
 					}
 				};
 			})}
-			withSearch={false}
+			searchPlaceHolder={'Nach Status (Fertig/Noch nicht bearbeitet) oder Titel durchsuchen'}
+			withSearch={true}
 		/>
 	</div>
 </div>

--- a/frontend/src/routes/milestonegroup/+page.svelte
+++ b/frontend/src/routes/milestonegroup/+page.svelte
@@ -29,7 +29,7 @@
 			header: 'Grobmotorik',
 			summary: 'something something',
 			image: imgJump,
-			href: `${base}/milestone`,
+			href: `${base}/milestoneoverview`,
 			progress: 0.75
 		},
 		{
@@ -37,28 +37,28 @@
 			summary:
 				'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt',
 			image: null,
-			href: `${base}/milestone`,
+			href: `${base}/milestoneoverview`,
 			progress: 1.0
 		},
 		{
 			header: 'Geistige Grundfunktionen',
 			summary: 'something something',
 			image: imgHead,
-			href: `${base}/milestone`,
+			href: `${base}/milestoneoverview`,
 			progress: 1.0
 		},
 		{
 			header: 'Höhere Denkfunktionen',
 			summary: 'something something',
 			image: null,
-			href: `${base}/milestone`,
+			href: `${base}/milestoneoverview`,
 			progress: 1.0
 		},
 		{
 			header: 'Sprache',
 			summary: 'how much noise the child makes',
 			image: null,
-			href: `${base}/milestone`,
+			href: `${base}/milestoneoverview`,
 			progress: 0.5
 		},
 		{
@@ -66,21 +66,21 @@
 			summary:
 				'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit.',
 			image: imgHead,
-			href: `${base}/milestone`,
+			href: `${base}/milestoneoverview`,
 			progress: 0.3
 		},
 		{
 			header: 'Selbstregulation',
 			summary: 'something something',
 			image: null,
-			href: `${base}/milestone`,
+			href: `${base}/milestoneoverview`,
 			progress: 0.6
 		},
 		{
 			header: 'Emotionen',
 			summary: 'something something',
 			image: null,
-			href: `${base}/milestone`,
+			href: `${base}/milestoneoverview`,
 			progress: 0.9
 		},
 		{
@@ -88,7 +88,7 @@
 			summary:
 				'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit.',
 			image: null,
-			href: `${base}/milestone`,
+			href: `${base}/milestoneoverview`,
 			progress: 0.3
 		}
 	];

--- a/frontend/src/routes/milestoneoverview/+page.svelte
+++ b/frontend/src/routes/milestoneoverview/+page.svelte
@@ -33,7 +33,7 @@
 				'Beobachten Sie, ob das Kind spontan oder nach Aufforderung von einer Treppenstufe oder einem ähnlich hohen Absatz springt! Es sollte tatsächlich mit beiden Beinen gleichzeitig losspringen, sich nirgends festhalten und beim Landen nicht mit der Hand abfangen. Sie sollten es beim Springen auch nicht an die Hand nehmen müssen. Wurde dieses Verhalten mehrmals sicher ausgeführt, gilt der Meilenstein zuverlässig gekonnt.  Ist das Kind noch leicht unsicher, springt meist mit beiden Beinen versetzt los, oder berührt beim Landen mit der Hand den Boden, ist das Verhalten weitgehend gekonnt. Wagt es den Sprung nur, wenn man seine Hand hält und/oder führt es den Sprung noch unsauber aus, ist das Verhalten in Ansätzen gekonnt. In allen anderen Fällen gilt der Meilenstein als noch nicht gekonnt.',
 			help: 'Beim Treppengehen im Haus, beim Spazierengehen oder auf dem Spielplatz bieten sich vielfältige Gelegenheiten, Kinder zum Springen von einem Absatz (z.B. einem höheren Bordstein. einem Holzstamm, oder einem Stein) zu ermutigen. Machen Sie Ihrem Kind die Bewegung vor oder führen Sie sie gemeinsam mit dem Kind durch. Nehmen Sie das Kind dafür zunächst bei an die Hand. Später können sie die Hand immer lockerer mitführen und die Eigenbewegung des Kindes nur noch passiv begleiten. So kann das Kind am besten selbst herausfinden, wie es seine Arme einsetzen muss, um Schwung zu holen und beim Landen das Gleichgewicht zu finden. Ist das Springen an der Hand sicher, lösen Sie die Hand ganz und stellen Sie sich gegenüber dem Kind hin, damit es weiß, dass es im Notfall aufgefangen wird.',
 			imgs: ['baby0.jpg', 'baby1.jpg', 'baby2.jpg'],
-			answer: null
+			answer: 'Vollständig gekonnt'
 		},
 		{
 			number: 2,
@@ -51,7 +51,7 @@
 			observation: 'Hier kommt der Beobachtungshilfetext hin',
 			help: 'Hier kommt der Förderhilfetext hin',
 			imgs: ['baby2.jpg'],
-			answer: null
+			answer: 'In Ansätzen gekonnt'
 		},
 		{
 			number: 4,

--- a/frontend/src/routes/milestoneoverview/+page.svelte
+++ b/frontend/src/routes/milestoneoverview/+page.svelte
@@ -70,4 +70,4 @@
 	const progress = 0.5;
 </script>
 
-<MilestoneOverview {breadcrumbdata} {data} {progress} {title} {desc} />
+<MilestoneOverview {breadcrumbdata} {data} />

--- a/frontend/src/routes/milestoneoverview/+page.svelte
+++ b/frontend/src/routes/milestoneoverview/+page.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+	import { base } from '$app/paths';
+	import MilestoneOverview from '$lib/components/MilestoneOverview.svelte';
+	const breadcrumbdata: any[] = [
+		{
+			href: `${base}/userLand/userDataInput`,
+			label: 'Benutzer'
+		},
+		{
+			href: `${base}/childrengallery`,
+			label: 'Kinderübersicht'
+		},
+		{
+			href: '#',
+			label: 'Meike'
+		},
+		{
+			href: `${base}/milestonegroup`,
+			label: 'Bereichsübersicht'
+		},
+		{
+			href: `${base}/milestoneoverview`,
+			label: `Grobmotorik`
+		}
+	];
+
+	const data = [
+		{
+			number: 1,
+			title: 'Alleine von Stufe/Absatz springen',
+			desc: 'Kind springt mit beiden Beinen gleichzeitig hoch und überwindet im Sprung freihändig einen (kleinen) Absatz oder eine Stufe. Es kommt sicher wieder im Stand auf.',
+			observation:
+				'Beobachten Sie, ob das Kind spontan oder nach Aufforderung von einer Treppenstufe oder einem ähnlich hohen Absatz springt! Es sollte tatsächlich mit beiden Beinen gleichzeitig losspringen, sich nirgends festhalten und beim Landen nicht mit der Hand abfangen. Sie sollten es beim Springen auch nicht an die Hand nehmen müssen. Wurde dieses Verhalten mehrmals sicher ausgeführt, gilt der Meilenstein zuverlässig gekonnt.  Ist das Kind noch leicht unsicher, springt meist mit beiden Beinen versetzt los, oder berührt beim Landen mit der Hand den Boden, ist das Verhalten weitgehend gekonnt. Wagt es den Sprung nur, wenn man seine Hand hält und/oder führt es den Sprung noch unsauber aus, ist das Verhalten in Ansätzen gekonnt. In allen anderen Fällen gilt der Meilenstein als noch nicht gekonnt.',
+			help: 'Beim Treppengehen im Haus, beim Spazierengehen oder auf dem Spielplatz bieten sich vielfältige Gelegenheiten, Kinder zum Springen von einem Absatz (z.B. einem höheren Bordstein. einem Holzstamm, oder einem Stein) zu ermutigen. Machen Sie Ihrem Kind die Bewegung vor oder führen Sie sie gemeinsam mit dem Kind durch. Nehmen Sie das Kind dafür zunächst bei an die Hand. Später können sie die Hand immer lockerer mitführen und die Eigenbewegung des Kindes nur noch passiv begleiten. So kann das Kind am besten selbst herausfinden, wie es seine Arme einsetzen muss, um Schwung zu holen und beim Landen das Gleichgewicht zu finden. Ist das Springen an der Hand sicher, lösen Sie die Hand ganz und stellen Sie sich gegenüber dem Kind hin, damit es weiß, dass es im Notfall aufgefangen wird.',
+			imgs: ['baby0.jpg', 'baby1.jpg', 'baby2.jpg'],
+			answer: null
+		},
+		{
+			number: 2,
+			title: 'Das Köpfchen alleine heben',
+			desc: 'Kind liegt auf dem Bauch, hält die Arme angewinkelt neben dem Körper und hebt sein Köpfchen aus eigener Kraft so hoch, dass das Kinn nicht mehr die Auflage berührt. Diese Position kann es mehr als 3 Sekunden halten.',
+			observation: 'Hier kommt der Beobachtungshilfetext hin',
+			help: 'Hier kommt der Förderhilfetext hin',
+			imgs: ['baby1.jpg'],
+			answer: null
+		},
+		{
+			number: 3,
+			title: 'Den Kopf frei bewegen',
+			desc: 'Kind kann seinen Kopf frei halten und bewegen, wenn es z.B. auf dem Schoß sitzt. Wenn man seinen Körper ein wenig schräg hält, gleicht es diese Bewegung mit dem Kopf aus. Der Kopf wackelt kaum oder gar nicht, wenn das Kind ihn dreht.',
+			observation: 'Hier kommt der Beobachtungshilfetext hin',
+			help: 'Hier kommt der Förderhilfetext hin',
+			imgs: ['baby2.jpg'],
+			answer: null
+		},
+		{
+			number: 4,
+			title: 'Sich in Bauchlage mit gestreckten Armen aufstützen',
+			desc: 'Kind liegt auf dem Bauch. Es stützt sich mit beiden Armen gestreckt von der Unterlage ab und hebt seinen Rücken an, um den Kopf aufrecht zu halten. Schultern und Brust liegen für mehr als 3 Sekunden nicht mehr auf der Unterlage.',
+			observation: 'Hier kommt der Beobachtungshilfetext hin',
+			help: 'Hier kommt der Förderhilfetext hin',
+			imgs: ['baby3.jpg'],
+			answer: null
+		}
+	];
+
+	const title = 'Grobmotorik';
+	const desc =
+		'Hier geht es darum, zu beschreiben, wie sich das Kind fortbewegt Und seinen Körper (Rumpf, Arme, Beine) kontrollieren kann.';
+	const progress = 0.5;
+</script>
+
+<MilestoneOverview {breadcrumbdata} {data} {progress} {title} {desc} />


### PR DESCRIPTION
- uses much the same visual buildingblocks as the milestonegroup page: `table of cards`
- uses button exposed by `CardDisplay` component to indicate status and allow for access to milestonepage
- allows for searching milestones by status or by part of header 
- displays status bar. Intention is to update it when new milestones are completed, but this has not yet been included
- uses breadcrumbs for navigation.
- adds ability to have a configurable Icon in the `CardDisplay` button 
- adds customizable `searchPlaceHolder` and seach function to the `GalleryDisplay`