### PR TITLE
Extend admin interface

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -2,3 +2,6 @@
 package-lock.json
 pnpm-lock.yaml
 yarn.lock
+# build artefacts
+.svelte-kit
+build

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,3 +14,5 @@ Initial setup to edit the frontend locally:
 To start a development server:
 
 - `pnpm run dev`
+
+This will serve the website at [http://localhost:5173](http://localhost:5173)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
 	},
 	"type": "module",
 	"dependencies": {
+		"iso-639-1": "3.1.3",
 		"svelte-i18n": "^4.0.0"
 	}
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      iso-639-1:
+        specifier: 3.1.3
+        version: 3.1.3
       svelte-i18n:
         specifier: ^4.0.0
         version: 4.0.0(svelte@4.2.19)
@@ -1374,6 +1377,10 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  iso-639-1@3.1.3:
+    resolution: {integrity: sha512-1jz0Wh9hyLMRwqEPchb/KZCiTqfFWtc9R3nm7GHPygBAKS8wdKJ3FH4lvLsri6UtAE5Kz5SnowtXZa//6bqMyw==}
+    engines: {node: '>=6.0'}
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
@@ -3570,6 +3577,8 @@ snapshots:
   is-stream@3.0.0: {}
 
   isexe@2.0.0: {}
+
+  iso-639-1@3.1.3: {}
 
   jackspeak@3.4.3:
     dependencies:

--- a/frontend/src/lib/admin.ts
+++ b/frontend/src/lib/admin.ts
@@ -1,0 +1,123 @@
+import { milestoneGroups } from '$lib/stores/adminStore';
+
+export async function refreshMilestoneGroups() {
+	console.log('refreshMilestoneGroups...');
+	try {
+		const res = await fetch(`${import.meta.env.VITE_MONDEY_API_URL}/admin/milestone-groups/`, {
+			method: 'GET',
+			credentials: 'include',
+			headers: {
+				'Content-Type': 'application/json',
+				Accept: 'application/json'
+			}
+		});
+		const json = await res.json();
+		console.log(json);
+		if (res.status === 200) {
+			milestoneGroups.set(json);
+		} else {
+			console.log('Failed to get MilestoneGroups');
+			milestoneGroups.set([]);
+		}
+	} catch (e) {
+		console.error(e);
+		milestoneGroups.set([]);
+	}
+}
+
+export async function newMilestoneGroup() {
+	console.log('newMilestoneGroup...');
+	try {
+		const res = await fetch(`${import.meta.env.VITE_MONDEY_API_URL}/admin/milestone-group/`, {
+			method: 'POST',
+			credentials: 'include',
+			headers: {
+				'Content-Type': 'application/json',
+				Accept: 'application/json'
+			}
+		});
+		if (res.status === 200) {
+			const newGroup = await res.json();
+			console.log(newGroup);
+			await refreshMilestoneGroups();
+			return newGroup;
+		} else {
+			console.log('Failed to create new MilestoneGroup');
+		}
+	} catch (e) {
+		console.error(e);
+	}
+	return null;
+}
+
+export async function patchMilestoneGroup(milestoneGroup) {
+	console.log('patchMilestoneGroup...');
+	console.log(milestoneGroup);
+	try {
+		const res = await fetch(`${import.meta.env.VITE_MONDEY_API_URL}/admin/milestone-group`, {
+			method: 'PATCH',
+			credentials: 'include',
+			headers: {
+				'Content-Type': 'application/json',
+				Accept: 'application/json'
+			},
+			body: JSON.stringify(milestoneGroup)
+		});
+		if (res.status === 200) {
+			const updatedGroup = await res.json();
+			console.log(updatedGroup);
+			await refreshMilestoneGroups();
+			return updatedGroup;
+		} else {
+			console.log('Failed to create new MilestoneGroup');
+		}
+	} catch (e) {
+		console.error(e);
+	}
+	return null;
+}
+
+export async function uploadMilestoneGroupImage(milestoneGroupId: number, file) {
+	console.log('uploadMilestoneGroupImage...');
+	try {
+		const formData = new FormData();
+		formData.append('file', file);
+		const res = await fetch(
+			`${import.meta.env.VITE_MONDEY_API_URL}/admin/upload-milestone-group-image/${milestoneGroupId}`,
+			{
+				method: 'POST',
+				credentials: 'include',
+				body: formData
+			}
+		);
+		console.log(await res.json());
+	} catch (e) {
+		console.error(e);
+	}
+}
+
+export async function deleteMilestoneGroup(milestoneGroupId: number | null) {
+	try {
+		const res = await fetch(
+			`${import.meta.env.VITE_MONDEY_API_URL}/admin/milestone-groups/${milestoneGroupId}`,
+			{
+				method: 'DELETE',
+				credentials: 'include',
+				headers: {
+					'Content-Type': 'application/json',
+					Accept: 'application/json'
+				}
+			}
+		);
+		const json = await res.json();
+		console.log(json);
+		if (res.status === 200) {
+			console.log(`Deleted MilestoneGroup with id ${milestoneGroupId}.`);
+			await refreshMilestoneGroups();
+		} else {
+			console.log(`Error deleting MilestoneGroup with id ${milestoneGroupId}.`);
+		}
+	} catch (e) {
+		console.error(e);
+	}
+}

--- a/frontend/src/lib/components/Admin/DeleteMilestoneGroupModal.svelte
+++ b/frontend/src/lib/components/Admin/DeleteMilestoneGroupModal.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import { Button, Modal } from 'flowbite-svelte';
+	import { ExclamationCircleOutline } from 'flowbite-svelte-icons';
+	import { deleteMilestoneGroup } from '$lib/admin';
+
+	export let open: boolean;
+	export let groupId: number | null;
+</script>
+
+<Modal bind:open size="xs" autoclose>
+	<div class="text-center">
+		<ExclamationCircleOutline class="mx-auto mb-4 h-12 w-12 text-gray-400 dark:text-gray-200" />
+		<h3 class="mb-5 text-lg font-normal text-gray-500 dark:text-gray-400">
+			Are you sure you want to delete this MilestoneGroup?
+		</h3>
+		<Button
+			color="red"
+			class="me-2"
+			on:click={() => {
+				deleteMilestoneGroup(groupId);
+			}}>Yes, I'm sure</Button
+		>
+		<Button color="alternative">No, cancel</Button>
+	</div>
+</Modal>

--- a/frontend/src/lib/components/Admin/EditMilestoneGroupModal.svelte
+++ b/frontend/src/lib/components/Admin/EditMilestoneGroupModal.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+	import {
+		Button,
+		InputAddon,
+		Textarea,
+		Input,
+		Label,
+		ButtonGroup,
+		Fileupload,
+		Modal
+	} from 'flowbite-svelte';
+	import { lang_id, languages } from '$lib/stores/adminStore';
+	import { patchMilestoneGroup, uploadMilestoneGroupImage } from '$lib/admin';
+
+	export let open: boolean = false;
+	export let milestoneGroup: object | null = null;
+
+	let files: FileList;
+	let image: string | ArrayBuffer | null | undefined = null;
+
+	$: if (milestoneGroup !== null) {
+		image = `${import.meta.env.VITE_MONDEY_API_URL}/static/milestone_group_${milestoneGroup.id}.jpg`;
+	}
+
+	$: if (files) {
+		const reader = new FileReader();
+		reader.readAsDataURL(files[0]);
+		reader.onload = (e) => {
+			image = e?.target?.result;
+		};
+	}
+
+	async function reloadImg(url) {
+		console.log(`Reloading ${url}`);
+		await fetch(url, { cache: 'reload', mode: 'no-cors' });
+		document.body.querySelectorAll(`img[src='${url}']`).forEach((img) => (img.src = url));
+	}
+
+	export async function saveChanges() {
+		try {
+			await patchMilestoneGroup(milestoneGroup);
+			if (files) {
+				await uploadMilestoneGroupImage(milestoneGroup.id, files[0]);
+				reloadImg(
+					`${import.meta.env.VITE_MONDEY_API_URL}/static/milestone_group_${milestoneGroup.id}.jpg`
+				);
+			}
+		} catch (e) {
+			console.error(e);
+		}
+	}
+</script>
+
+<Modal title="Edit milestone group" bind:open autoclose size="xl">
+	{#if milestoneGroup}
+		<div class="mb-5">
+			<Label class="mb-2">Title</Label>
+			{#each Object.entries(milestoneGroup.text) as [lang_id, text]}
+				<div class="mb-1">
+					<ButtonGroup class="w-full">
+						<InputAddon>{$languages[text.lang_id]}</InputAddon>
+						<Input bind:value={text.title} placeholder="Title" />
+					</ButtonGroup>
+				</div>
+			{/each}
+		</div>
+		<div class="mb-5">
+			<Label class="mb-2">Description</Label>
+			{#each Object.entries(milestoneGroup.text) as [lang_id, text]}
+				<div class="mb-1">
+					<ButtonGroup class="w-full">
+						<InputAddon>{$languages[text.lang_id]}</InputAddon>
+						<Textarea bind:value={text.desc} placeholder="Description" />
+					</ButtonGroup>
+				</div>
+			{/each}
+		</div>
+		<div class="mb-5">
+			<Label for="img_upload" class="pb-2">Image</Label>
+			<div class="flex flex-row">
+				<img src={image} width="48" height="48" alt="MilestoneGroup" class="mx-2" />
+				<Fileupload bind:files accept=".jpg, .jpeg" id="img_upload" class="mb-2 flex-grow-0" />
+			</div>
+		</div>
+	{/if}
+	<svelte:fragment slot="footer">
+		<Button color="green" on:click={saveChanges}>Save changes</Button>
+		<Button color="alternative">Cancel</Button>
+	</svelte:fragment>
+</Modal>

--- a/frontend/src/lib/components/Admin/Languages.svelte
+++ b/frontend/src/lib/components/Admin/Languages.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+	import {
+		Table,
+		TableBody,
+		TableBodyCell,
+		TableBodyRow,
+		TableHead,
+		TableHeadCell,
+		Card,
+		Button,
+		Select
+	} from 'flowbite-svelte';
+	import { PlusOutline } from 'flowbite-svelte-icons';
+	import ISO6391 from 'iso-639-1';
+	import { _ } from 'svelte-i18n';
+	import type { SelectOptionType } from 'flowbite-svelte';
+	import { updateLanguages } from '$lib/i18n';
+	import { languages } from '$lib/stores/adminStore';
+
+	const langCodes = ISO6391.getAllCodes();
+	const langNames = ISO6391.getAllNativeNames();
+	const langItems = langCodes.reduce(
+		(acc, k, i) => [...acc, { value: k, name: langNames[i] }],
+		[] as SelectOptionType<string>[]
+	);
+	let selectedLang: string = '';
+
+	async function newLanguage() {
+		try {
+			const res = await fetch(`${import.meta.env.VITE_MONDEY_API_URL}/admin/language`, {
+				method: 'POST',
+				credentials: 'include',
+				headers: {
+					'Content-Type': 'application/json',
+					Accept: 'application/json'
+				},
+				body: JSON.stringify({ lang: selectedLang })
+			});
+			if (res.status === 200) {
+				await updateLanguages();
+			} else {
+				console.log('Failed to create new Language');
+			}
+		} catch (e) {
+			console.error(e);
+		}
+	}
+
+	async function deleteLanguage(id: string) {
+		try {
+			const res = await fetch(`${import.meta.env.VITE_MONDEY_API_URL}/admin/language/${id}`, {
+				method: 'DELETE',
+				credentials: 'include',
+				headers: {
+					'Content-Type': 'application/json',
+					Accept: 'application/json'
+				}
+			});
+			if (res.status === 200) {
+				await updateLanguages();
+			} else {
+				console.log('Failed to create new Language');
+			}
+		} catch (e) {
+			console.error(e);
+		}
+	}
+</script>
+
+<Card size="xl" class="m-5">
+	<h3 class="mb-3 text-xl font-medium text-gray-900 dark:text-white">{$_('admin.languages')}</h3>
+	<Table>
+		<TableHead>
+			<TableHeadCell>Code (ISO 639-1)</TableHeadCell>
+			<TableHeadCell>Name</TableHeadCell>
+			<TableHeadCell>Actions</TableHeadCell>
+		</TableHead>
+		<TableBody>
+			{#each Object.entries($languages) as [id, lang]}
+				<TableBodyRow>
+					<TableBodyCell>
+						{lang}
+					</TableBodyCell>
+					<TableBodyCell>
+						{ISO6391.getNativeName(lang)}
+					</TableBodyCell>
+					<TableBodyCell>
+						<Button
+							color="red"
+							on:click={() => {
+								deleteLanguage(id);
+							}}>Delete</Button
+						>
+					</TableBodyCell>
+				</TableBodyRow>
+			{/each}
+			<TableBodyRow>
+				<TableBodyCell></TableBodyCell>
+				<TableBodyCell>
+					<Select
+						class="mt-2"
+						items={langItems}
+						bind:value={selectedLang}
+						placeholder="Select a language..."
+					/>
+				</TableBodyCell>
+				<TableBodyCell>
+					<Button color="blue" on:click={newLanguage} disabled={selectedLang === ''}
+						><PlusOutline class="mr-2"></PlusOutline>Add language</Button
+					>
+				</TableBodyCell>
+			</TableBodyRow>
+		</TableBody>
+	</Table>
+</Card>

--- a/frontend/src/lib/components/Admin/MilestoneGroups.svelte
+++ b/frontend/src/lib/components/Admin/MilestoneGroups.svelte
@@ -1,54 +1,128 @@
 <script lang="ts">
-	import { AccordionItem, Accordion, Card } from 'flowbite-svelte';
+	import {
+		Table,
+		TableBody,
+		TableBodyCell,
+		TableBodyRow,
+		TableHead,
+		TableHeadCell,
+		Card,
+		Button
+	} from 'flowbite-svelte';
+	import { _ } from 'svelte-i18n';
+	import { ChevronUpOutline, ChevronDownOutline, PlusOutline } from 'flowbite-svelte-icons';
+	import EditMilestoneGroupModal from '$lib/components/Admin/EditMilestoneGroupModal.svelte';
+	import DeleteMilestoneGroupModal from '$lib/components/Admin/DeleteMilestoneGroupModal.svelte';
+	import { lang_id, milestoneGroups } from '$lib/stores/adminStore';
+	import { refreshMilestoneGroups, newMilestoneGroup } from '$lib/admin';
+	import { onMount } from 'svelte';
 
-	let milestoneGroups: Array<object> = [];
+	let currentGroup: object | null = null;
+	let openGroupIndex: number | null = null;
+	let currentGroupId: number | null = null;
+	let showEditGroupModal: boolean = false;
+	let showDeleteGroupModal: boolean = false;
 
-	async function getMilestoneGroups() {
-		try {
-			const res = await fetch(`${import.meta.env.VITE_MONDEY_API_URL}/admin/milestone-groups/`, {
-				method: 'GET',
-				credentials: 'include',
-				headers: {
-					'Content-Type': 'application/json',
-					Accept: 'application/json'
-				}
-			});
-			const json = await res.json();
-			console.log(json);
-			if (res.status === 200) {
-				milestoneGroups = json;
-			} else {
-				milestoneGroups = [];
-			}
-		} catch (e) {
-			console.error(e);
-			milestoneGroups = [];
+	function toggleOpenGroupIndex(index: number) {
+		if (openGroupIndex == index) {
+			openGroupIndex = null;
+		} else {
+			openGroupIndex = index;
 		}
 	}
 
-	getMilestoneGroups();
+	async function addMilestoneGroup() {
+		currentGroup = await newMilestoneGroup();
+		if (currentGroup === null) {
+			return;
+		}
+		openGroupIndex = null;
+		showEditGroupModal = true;
+	}
+
+	onMount(async () => {
+		await refreshMilestoneGroups();
+	});
 </script>
 
 <Card size="xl" class="m-5">
-	<Accordion>
-		{#each milestoneGroups as milestoneGroup}
-			<AccordionItem>
-				<span slot="header">
-					<div class="flex flex-row flex-wrap items-center">
-						<img
-							src={`${import.meta.env.VITE_MONDEY_API_URL}/static/milestone_group_${milestoneGroup.id}.jpg`}
-							width="100"
-							height="100"
-							alt={milestoneGroup.text.de.title}
-							class="p-2"
-						/>
-						<h5 class="mb-5 text-center text-2xl font-bold text-gray-900 dark:text-white">
-							{milestoneGroup.text.de.title}
-						</h5>
-					</div>
-				</span>
-				{milestoneGroup.text.de.desc}
-			</AccordionItem>
-		{/each}
-	</Accordion>
+	<h3 class="mb-3 text-xl font-medium text-gray-900 dark:text-white">
+		{$_('admin.milestonegroups')}
+	</h3>
+	{#if milestoneGroups}
+		<Table>
+			<TableHead>
+				<TableHeadCell></TableHeadCell>
+				<TableHeadCell>Image</TableHeadCell>
+				<TableHeadCell>Title</TableHeadCell>
+				<TableHeadCell>Actions</TableHeadCell>
+			</TableHead>
+			<TableBody>
+				{#each $milestoneGroups as milestoneGroup, groupIndex (milestoneGroup.id)}
+					{@const title = milestoneGroup?.text[$lang_id]?.title}
+					<TableBodyRow
+						on:click={() => {
+							toggleOpenGroupIndex(groupIndex);
+						}}
+						class={openGroupIndex === null || openGroupIndex === groupIndex
+							? 'opacity-100'
+							: 'opacity-25'}
+					>
+						<TableBodyCell>
+							{#if openGroupIndex === groupIndex}
+								<ChevronUpOutline />
+							{:else}
+								<ChevronDownOutline />
+							{/if}
+						</TableBodyCell>
+						<TableBodyCell>
+							<img
+								src={`${import.meta.env.VITE_MONDEY_API_URL}/static/milestone_group_${milestoneGroup.id}.jpg`}
+								width="64"
+								height="64"
+								alt={title}
+								class="p-2"
+							/>
+						</TableBodyCell>
+						<TableBodyCell>
+							{title}
+						</TableBodyCell>
+						<TableBodyCell>
+							<Button
+								color="yellow"
+								on:click={() => {
+									currentGroup = $milestoneGroups[groupIndex];
+									showEditGroupModal = true;
+								}}>Edit</Button
+							>
+							<Button
+								color="red"
+								on:click={() => {
+									currentGroupId = milestoneGroup.id;
+									showDeleteGroupModal = true;
+								}}>Delete</Button
+							>
+						</TableBodyCell>
+					</TableBodyRow>
+				{/each}
+				<TableBodyRow>
+					<TableBodyCell></TableBodyCell>
+					<TableBodyCell></TableBodyCell>
+					<TableBodyCell></TableBodyCell>
+					<TableBodyCell>
+						<Button color="blue" on:click={addMilestoneGroup}
+							><PlusOutline class="mr-2"></PlusOutline>Add milestone group</Button
+						>
+					</TableBodyCell>
+				</TableBodyRow>
+			</TableBody>
+		</Table>
+	{/if}
 </Card>
+
+{#key showEditGroupModal}
+	<EditMilestoneGroupModal bind:open={showEditGroupModal} milestoneGroup={currentGroup}
+	></EditMilestoneGroupModal>
+{/key}
+<DeleteMilestoneGroupModal bind:open={showDeleteGroupModal} groupId={currentGroupId}
+></DeleteMilestoneGroupModal>

--- a/frontend/src/lib/components/Admin/NewMilestoneGroupModal.svelte
+++ b/frontend/src/lib/components/Admin/NewMilestoneGroupModal.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
 	import {
-		Card,
 		Button,
 		InputAddon,
 		Textarea,
 		Input,
 		Label,
 		ButtonGroup,
-		Fileupload
+		Fileupload,
+		Modal
 	} from 'flowbite-svelte';
 	import { FileImageSolid } from 'flowbite-svelte-icons';
 
+	export let open: boolean = false;
 	export let milestoneGroupData = {
 		group: { order: 0 },
 		text: [
@@ -20,7 +21,6 @@
 	};
 	let files: FileList;
 	let image: string | ArrayBuffer | null | undefined = '';
-	let result = '';
 
 	$: if (files) {
 		const reader = new FileReader();
@@ -47,7 +47,6 @@
 			);
 			const new_milestone_group = await res_milestone_group.json();
 			console.log(new_milestone_group);
-			result = JSON.stringify(new_milestone_group);
 			if (files) {
 				let formData = new FormData();
 				formData.append('file', files[0]);
@@ -68,10 +67,7 @@
 	}
 </script>
 
-<Card size="xl">
-	<h5 class="mb-5 text-center text-2xl font-bold text-gray-900 dark:text-white">
-		New MilestoneGroup
-	</h5>
+<Modal title="Create milestone group" bind:open autoclose size="xl">
 	<div class="mb-5">
 		<Label class="mb-2">Title</Label>
 		{#each milestoneGroupData.text as text}
@@ -96,13 +92,17 @@
 	</div>
 	<div class="mb-5">
 		<Label for="img_upload" class="pb-2">Image</Label>
-		{#if image}
-			<img src={`${image ?? ''}`} width="100" height="100" alt="MilestoneGroup" />
-		{:else}
-			<FileImageSolid class="h-[100px] w-[100px]" />
-		{/if}
-		<Fileupload bind:files accept=".jpg, .jpeg" id="img_upload" class="mb-2" />
+		<div class="flex flex-row">
+			{#if image}
+				<img src={`${image ?? ''}`} width="48" height="48" alt="MilestoneGroup" class="mx-2" />
+			{:else}
+				<FileImageSolid class="h-[48px] w-[48px]" />
+			{/if}
+			<Fileupload bind:files accept=".jpg, .jpeg" id="img_upload" class="mb-2 flex-grow-0" />
+		</div>
 	</div>
-	<Button class="w-full" on:click={postMilestoneGroup}>Create</Button>
-</Card>
-<h1>{result}</h1>
+	<svelte:fragment slot="footer">
+		<Button color="green" on:click={postMilestoneGroup}>Save changes</Button>
+		<Button color="alternative">Cancel</Button>
+	</svelte:fragment>
+</Modal>

--- a/frontend/src/lib/components/LocaleChooser.svelte
+++ b/frontend/src/lib/components/LocaleChooser.svelte
@@ -2,6 +2,8 @@
 	import { Dropdown, DropdownItem } from 'flowbite-svelte';
 	import { ChevronDownOutline } from 'flowbite-svelte-icons';
 	import { locale, locales } from 'svelte-i18n';
+	import { languages, lang_id } from '$lib/stores/adminStore';
+
 	let dropdownOpen = false;
 </script>
 
@@ -20,6 +22,7 @@
 				class="flex items-center"
 				on:click={() => {
 					locale.set(loc);
+					lang_id.set(`${Object.keys($languages).find((key) => $languages[key] === loc)}`);
 					dropdownOpen = false;
 				}}
 			>

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -1,4 +1,5 @@
-import { register, init, getLocaleFromNavigator } from 'svelte-i18n';
+import { register, init } from 'svelte-i18n';
+import { lang_id, languages } from '$lib/stores/adminStore';
 
 register('de', () => import('../locales/de.json'));
 register('en', () => import('../locales/en.json'));
@@ -7,3 +8,21 @@ init({
 	fallbackLocale: 'de',
 	initialLocale: 'de'
 });
+
+export async function updateLanguages() {
+	try {
+		const res = await fetch(`${import.meta.env.VITE_MONDEY_API_URL}/languages`, {
+			method: 'GET',
+			credentials: 'include',
+			headers: {
+				'Content-Type': 'application/json',
+				Accept: 'application/json'
+			}
+		});
+		if (res.status === 200) {
+			languages.set(await res.json());
+		}
+	} catch (e) {
+		console.error(e);
+	}
+}

--- a/frontend/src/lib/stores/adminStore.ts
+++ b/frontend/src/lib/stores/adminStore.ts
@@ -1,3 +1,9 @@
 import { writable } from 'svelte/store';
 
 export const isLoggedIn = writable(false);
+
+export const milestoneGroups = writable([]);
+
+export const languages = writable({});
+
+export const lang_id = writable('1');

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -22,5 +22,9 @@
 		"next": "Weiter",
 		"prev": "Zurück",
 		"autonext": "Automatisch weiter"
+	},
+	"admin": {
+		"languages": "Sprachen",
+		"milestonegroups": "Meilensteingruppen"
 	}
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -22,5 +22,9 @@
 		"next": "Next",
 		"prev": "Back",
 		"autonext": "Continue automatically"
+	},
+	"admin": {
+		"languages": "Languages",
+		"milestonegroups": "Milestone groups"
 	}
 }

--- a/frontend/src/routes/admin/+page.svelte
+++ b/frontend/src/routes/admin/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
 	import { isLoggedIn } from '$lib/stores/adminStore';
-	import MilestoneGroup from '$lib/components/Admin/MilestoneGroup.svelte';
+	import { updateLanguages } from '$lib/i18n';
+	import Languages from '$lib/components/Admin/Languages.svelte';
 	import MilestoneGroups from '$lib/components/Admin/MilestoneGroups.svelte';
 	import Login from '$lib/components/Admin/Login.svelte';
+	import { onMount } from 'svelte';
 
 	async function updateIsLoggedIn() {
 		const res = await fetch(`${import.meta.env.VITE_MONDEY_API_URL}/users/me`, {
@@ -15,21 +16,17 @@
 		}
 	}
 
-	onMount(() => {
+	onMount(async () => {
+		updateLanguages();
 		updateIsLoggedIn();
-	});
-
-	let isLoggedInValue: boolean;
-	const unsubscribe = isLoggedIn.subscribe((value) => {
-		isLoggedInValue = value;
 	});
 </script>
 
 <div class="flex w-full flex-col items-center justify-center">
-	{#if !isLoggedInValue}
+	{#if !$isLoggedIn}
 		<Login />
 	{:else}
+		<Languages />
 		<MilestoneGroups />
-		<MilestoneGroup />
 	{/if}
 </div>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,5 +7,10 @@ export default defineConfig({
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}'],
 		environment: 'jsdom'
+	},
+	server: {
+		host: 'localhost',
+		port: 5173,
+		strictPort: true
 	}
 });

--- a/mondey_backend/src/mondey_backend/main.py
+++ b/mondey_backend/src/mondey_backend/main.py
@@ -38,7 +38,7 @@ app.mount(
 if app_settings.ENABLE_CORS:
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["http://localhost:4173", "http://localhost:5173"],
+        allow_origins=["http://localhost:5173"],
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/mondey_backend/src/mondey_backend/routers/admin.py
+++ b/mondey_backend/src/mondey_backend/routers/admin.py
@@ -10,18 +10,119 @@ from sqlmodel import select
 
 from ..dependencies import AdminDep
 from ..dependencies import SessionDep
+from ..models.milestones import Language
+from ..models.milestones import LanguageCreate
 from ..models.milestones import Milestone
 from ..models.milestones import MilestoneCreate
 from ..models.milestones import MilestoneGroup
 from ..models.milestones import MilestoneGroupAdmin
-from ..models.milestones import MilestoneGroupCreate
 from ..models.milestones import MilestoneGroupText
-from ..models.milestones import MilestoneGroupTextCreate
-from ..models.milestones import MilestoneGroupUpdate
 from ..models.milestones import MilestonePublic
 from ..models.milestones import MilestoneUpdate
 
 router = APIRouter(prefix="/admin", tags=["admin"], dependencies=[AdminDep])
+
+
+@router.post("/language/", response_model=Language)
+def create_language(session: SessionDep, language: LanguageCreate):
+    db_language = Language.model_validate(language)
+    session.add(db_language)
+    session.commit()
+    session.refresh(db_language)
+    return db_language
+
+
+@router.delete("/language/{language_id}", response_model=Language)
+def delete_language(session: SessionDep, language_id: str):
+    language = session.get(Language, language_id)
+    if not language:
+        raise HTTPException(status_code=404, detail="language not found")
+    session.delete(language)
+    session.commit()
+    return {"ok": True}
+
+
+@router.get("/milestone-groups/", response_model=list[MilestoneGroupAdmin])
+def get_milestone_groups(session: SessionDep):
+    milestone_groups = session.exec(
+        select(MilestoneGroup).order_by(col(MilestoneGroup.order))
+    ).all()
+    return milestone_groups
+
+
+@router.post("/milestone-group/", response_model=MilestoneGroupAdmin)
+def create_milestone_group(session: SessionDep):
+    db_milestone_group = MilestoneGroup(order=0, image=None)
+    session.add(db_milestone_group)
+    session.commit()
+    session.refresh(db_milestone_group)
+    for language in session.exec(select(Language)).all():
+        session.add(
+            MilestoneGroupText(
+                group_id=db_milestone_group.id, lang_id=language.id, title="", desc=""
+            )
+        )
+    session.commit()
+    session.refresh(db_milestone_group)
+    return db_milestone_group
+
+
+@router.patch("/milestone-group", response_model=MilestoneGroupAdmin)
+def update_milestone_group(
+    session: SessionDep,
+    milestone_group: MilestoneGroupAdmin,
+):
+    db_milestone_group = session.get(MilestoneGroup, milestone_group.id)
+    if not db_milestone_group:
+        raise HTTPException(status_code=404, detail="milestone_group not found")
+    for key, value in milestone_group.model_dump(
+        exclude={"text", "milestones"}
+    ).items():
+        setattr(db_milestone_group, key, value)
+    for text in milestone_group.text.values():
+        db_milestone_group_text = session.get(
+            MilestoneGroupText, (text.group_id, text.lang_id)
+        )
+        if not db_milestone_group_text:
+            db_milestone_group_text = text
+        else:
+            for key, value in text.model_dump().items():
+                setattr(db_milestone_group_text, key, value)
+        session.add(db_milestone_group_text)
+    session.add(db_milestone_group)
+    session.commit()
+    session.refresh(db_milestone_group)
+    return db_milestone_group
+
+
+@router.delete("/milestone-groups/{milestone_group_id}")
+def delete_milestone_group(session: SessionDep, milestone_group_id: int):
+    milestone_group = session.get(MilestoneGroup, milestone_group_id)
+    if not milestone_group:
+        raise HTTPException(status_code=404, detail="milestone_group not found")
+    session.delete(milestone_group)
+    session.commit()
+    return {"ok": True}
+
+
+@router.post("/upload-milestone-group-image/{milestone_group_id}")
+async def upload_milestone_group_image(
+    session: SessionDep, milestone_group_id: int, file: UploadFile
+):
+    milestone_group = session.get(MilestoneGroup, milestone_group_id)
+    filename = f"static/milestone_group_{milestone_group_id}.jpg"
+    if not milestone_group:
+        raise HTTPException(status_code=404, detail="milestone_group not found")
+    try:
+        contents = file.file.read()
+        with open(filename, "wb") as f:
+            f.write(contents)
+    except Exception as e:
+        logging.exception(e)
+        raise HTTPException(status_code=404, detail="Error uploading file") from e
+    finally:
+        file.file.close()
+    return {"filename": filename}
 
 
 @router.post("/milestones/", response_model=MilestonePublic)
@@ -59,80 +160,3 @@ def delete_milestone(session: SessionDep, milestone_id: int):
     session.delete(milestone)
     session.commit()
     return {"ok": True}
-
-
-@router.get("/milestone-groups/", response_model=list[MilestoneGroupAdmin])
-def get_milestone_groups(session: SessionDep):
-    milestone_groups = session.exec(
-        select(MilestoneGroup).order_by(col(MilestoneGroup.order))
-    ).all()
-    return milestone_groups
-
-
-@router.post("/milestone-groups/", response_model=MilestoneGroupAdmin)
-def create_milestone_group(
-    session: SessionDep,
-    group: MilestoneGroupCreate,
-    text: list[MilestoneGroupTextCreate],
-):
-    logging.critical(f"{group}")
-    db_milestone_group = MilestoneGroup.model_validate(group)
-    session.add(db_milestone_group)
-    session.commit()
-    session.refresh(db_milestone_group)
-    for milestone_group_text in text:
-        db_milestone_group_text = MilestoneGroupText.model_validate(
-            milestone_group_text, update={"group_id": db_milestone_group.id}
-        )
-        session.add(db_milestone_group_text)
-    session.commit()
-    return db_milestone_group
-
-
-@router.patch(
-    "/milestone-groups/{milestone_group_id}", response_model=MilestoneGroupAdmin
-)
-def update_milestone_group(
-    session: SessionDep,
-    milestone_group_id: int,
-    milestone_group: MilestoneGroupUpdate,
-):
-    db_milestone_group = session.get(MilestoneGroup, milestone_group_id)
-    if not db_milestone_group:
-        raise HTTPException(status_code=404, detail="milestone_group not found")
-    for key, value in milestone_group.model_dump().items():
-        setattr(db_milestone_group, key, value)
-    session.add(db_milestone_group)
-    session.commit()
-    session.refresh(db_milestone_group)
-    return db_milestone_group
-
-
-@router.delete("/milestone-groups/{milestone_group_id}")
-def delete_milestone_group(session: SessionDep, milestone_group_id: int):
-    milestone_group = session.get(MilestoneGroup, milestone_group_id)
-    if not milestone_group:
-        raise HTTPException(status_code=404, detail="milestone_group not found")
-    session.delete(milestone_group)
-    session.commit()
-    return {"ok": True}
-
-
-@router.post("/upload-milestone-group-image/{milestone_group_id}")
-async def upload_milestone_group_image(
-    session: SessionDep, milestone_group_id: int, file: UploadFile
-):
-    milestone_group = session.get(MilestoneGroup, milestone_group_id)
-    filename = f"static/milestone_group_{milestone_group_id}.jpg"
-    if not milestone_group:
-        raise HTTPException(status_code=404, detail="milestone_group not found")
-    try:
-        contents = file.file.read()
-        with open(filename, "wb") as f:
-            f.write(contents)
-    except Exception as e:
-        logging.exception(e)
-        raise HTTPException(status_code=404, detail="Error uploading file") from e
-    finally:
-        file.file.close()
-    return {"filename": filename}

--- a/mondey_backend/src/mondey_backend/routers/milestones.py
+++ b/mondey_backend/src/mondey_backend/routers/milestones.py
@@ -6,12 +6,22 @@ from sqlmodel import col
 from sqlmodel import select
 
 from ..dependencies import SessionDep
+from ..models.milestones import Language
 from ..models.milestones import Milestone
 from ..models.milestones import MilestoneGroup
 from ..models.milestones import MilestoneGroupPublic
 from ..models.milestones import MilestonePublic
 
 router = APIRouter(tags=["milestones"])
+
+
+@router.get("/languages/", response_model=dict[int, str])
+def get_languages(
+    session: SessionDep,
+):
+    return {
+        language.id: language.lang for language in session.exec(select(Language)).all()
+    }
 
 
 @router.get("/milestones/", response_model=list[MilestonePublic])

--- a/mondey_backend/tests/conftest.py
+++ b/mondey_backend/tests/conftest.py
@@ -6,6 +6,7 @@ from mondey_backend.dependencies import current_active_superuser
 from mondey_backend.dependencies import current_active_user
 from mondey_backend.dependencies import get_session
 from mondey_backend.main import app
+from mondey_backend.models.milestones import Language
 from mondey_backend.models.milestones import MilestoneGroup
 from mondey_backend.models.milestones import MilestoneGroupText
 from mondey_backend.models.users import UserRead
@@ -27,13 +28,16 @@ def session():
     SQLModel.metadata.create_all(engine)
     with Session(engine) as session:
         # add some test data to the database
-        session.add(MilestoneGroup(order=2, image=None))
-        session.add(MilestoneGroupText(group_id=1, lang="de", title="t1", desc="d1"))
-        session.add(MilestoneGroupText(group_id=1, lang="en", title="t2", desc="d2"))
-        session.add(MilestoneGroup(order=1, image=None))
-        session.add(MilestoneGroupText(group_id=2, lang="de", title="t3", desc="d3"))
-        session.add(MilestoneGroupText(group_id=2, lang="en", title="t4", desc="d4"))
-        session.add(MilestoneGroupText(group_id=2, lang="fr", title="t5", desc="d5"))
+        session.add(Language(lang="de"))
+        session.add(Language(lang="en"))
+        session.add(Language(lang="fr"))
+        session.add(MilestoneGroup(order=2))
+        session.add(MilestoneGroupText(group_id=1, lang_id=1, title="t1", desc="d1"))
+        session.add(MilestoneGroupText(group_id=1, lang_id=2, title="t2", desc="d2"))
+        session.add(MilestoneGroup(order=1))
+        session.add(MilestoneGroupText(group_id=2, lang_id=1, title="t3", desc="d3"))
+        session.add(MilestoneGroupText(group_id=2, lang_id=2, title="t4", desc="d4"))
+        session.add(MilestoneGroupText(group_id=2, lang_id=3, title="t5", desc="d5"))
         session.commit()
         yield session
 

--- a/mondey_backend/tests/routers/test_admin.py
+++ b/mondey_backend/tests/routers/test_admin.py
@@ -1,6 +1,18 @@
 from fastapi.testclient import TestClient
 
 
+def test_post_language(admin_client: TestClient):
+    response = admin_client.post("/admin/language/", json={"lang": "es"})
+    assert response.status_code == 200
+    assert response.json() == {"id": 4, "lang": "es"}
+
+
+def test_delete_language(admin_client: TestClient):
+    response = admin_client.delete("/admin/language/2")
+    assert response.status_code == 200
+    assert admin_client.get("/languages").json() == {"1": "de", "3": "fr"}
+
+
 def test_get_milestone_groups(admin_client: TestClient):
     response = admin_client.get("/admin/milestone-groups/")
     assert response.status_code == 200
@@ -10,12 +22,21 @@ def test_get_milestone_groups(admin_client: TestClient):
         "id": 2,
         "order": 1,
         "text": {
-            "de": {"id": 3, "group_id": 2, "lang": "de", "title": "t3", "desc": "d3"},
-            "en": {"id": 4, "group_id": 2, "lang": "en", "title": "t4", "desc": "d4"},
-            "fr": {
-                "id": 5,
+            "1": {
                 "group_id": 2,
-                "lang": "fr",
+                "lang_id": 1,
+                "title": "t3",
+                "desc": "d3",
+            },
+            "2": {
+                "group_id": 2,
+                "lang_id": 2,
+                "title": "t4",
+                "desc": "d4",
+            },
+            "3": {
+                "group_id": 2,
+                "lang_id": 3,
                 "title": "t5",
                 "desc": "d5",
             },
@@ -26,40 +47,47 @@ def test_get_milestone_groups(admin_client: TestClient):
         "id": 1,
         "order": 2,
         "text": {
-            "de": {"id": 1, "group_id": 1, "lang": "de", "title": "t1", "desc": "d1"},
-            "en": {"id": 2, "group_id": 1, "lang": "en", "title": "t2", "desc": "d2"},
+            "1": {
+                "group_id": 1,
+                "lang_id": 1,
+                "title": "t1",
+                "desc": "d1",
+            },
+            "2": {
+                "group_id": 1,
+                "lang_id": 2,
+                "title": "t2",
+                "desc": "d2",
+            },
         },
         "milestones": [],
     }
 
 
-def test_post_milestone_groups(admin_client: TestClient):
-    data = {
-        "group": {"order": 0},
-        "text": [
-            {"lang": "en", "title": "title1", "desc": "desc1"},
-            {"lang": "de", "title": "title2", "desc": "desc2"},
-        ],
-    }
-    response = admin_client.post("/admin/milestone-groups/", json=data)
+def test_post_milestone_group(admin_client: TestClient):
+    response = admin_client.post("/admin/milestone-group/")
     assert response.status_code == 200
     assert response.json() == {
         "id": 3,
         "order": 0,
         "text": {
-            "en": {
-                "id": 6,
-                "lang": "en",
+            "1": {
                 "group_id": 3,
-                "title": "title1",
-                "desc": "desc1",
+                "lang_id": 1,
+                "title": "",
+                "desc": "",
             },
-            "de": {
-                "id": 7,
-                "lang": "de",
+            "2": {
                 "group_id": 3,
-                "title": "title2",
-                "desc": "desc2",
+                "lang_id": 2,
+                "title": "",
+                "desc": "",
+            },
+            "3": {
+                "group_id": 3,
+                "lang_id": 3,
+                "title": "",
+                "desc": "",
             },
         },
         "milestones": [],
@@ -67,20 +95,15 @@ def test_post_milestone_groups(admin_client: TestClient):
 
 
 def test_patch_milestone_groups(admin_client: TestClient):
-    data = {
-        "order": 3,
-    }
-    response = admin_client.patch("/admin/milestone-groups/1", json=data)
+    data = admin_client.get("/admin/milestone-groups").json()[0]
+    data["order"] = 6
+    data["text"]["1"]["title"] = "asdsd"
+    data["text"]["1"]["desc"] = "12xzascdasdf"
+    data["text"]["2"]["title"] = "asqwdreqweqw"
+    data["text"]["2"]["desc"] = "th567"
+    response = admin_client.patch("/admin/milestone-group", json=data)
     assert response.status_code == 200
-    assert response.json() == {
-        "id": 1,
-        "order": 3,
-        "text": {
-            "de": {"id": 1, "group_id": 1, "lang": "de", "title": "t1", "desc": "d1"},
-            "en": {"id": 2, "group_id": 1, "lang": "en", "title": "t2", "desc": "d2"},
-        },
-        "milestones": [],
-    }
+    assert response.json() == data
 
 
 def test_admin_delete_milestone_group(admin_client: TestClient):

--- a/mondey_backend/tests/routers/test_milestones.py
+++ b/mondey_backend/tests/routers/test_milestones.py
@@ -3,6 +3,12 @@ import pytest
 
 @pytest.mark.parametrize("client_type", ["user_client", "admin_client"])
 class TestMilestones:
+    def test_get_languages(self, client_type: str, request: pytest.FixtureRequest):
+        client = request.getfixturevalue(client_type)
+        response = client.get("/languages/")
+        assert response.status_code == 200
+        assert response.json() == {"1": "de", "2": "en", "3": "fr"}
+
     def test_get_milestone_groups(
         self, client_type: str, request: pytest.FixtureRequest
     ):
@@ -13,20 +19,18 @@ class TestMilestones:
         group1, group2 = response.json()
         assert group1 == {
             "id": 2,
-            "order": 1,
             "text": {
-                "de": {"title": "t3", "desc": "d3"},
-                "en": {"title": "t4", "desc": "d4"},
-                "fr": {"title": "t5", "desc": "d5"},
+                "1": {"title": "t3", "desc": "d3"},
+                "2": {"title": "t4", "desc": "d4"},
+                "3": {"title": "t5", "desc": "d5"},
             },
             "milestones": [],
         }
         assert group2 == {
             "id": 1,
-            "order": 2,
             "text": {
-                "de": {"title": "t1", "desc": "d1"},
-                "en": {"title": "t2", "desc": "d2"},
+                "1": {"title": "t1", "desc": "d1"},
+                "2": {"title": "t2", "desc": "d2"},
             },
             "milestones": [],
         }
@@ -39,11 +43,10 @@ class TestMilestones:
         assert response.status_code == 200
         assert response.json() == {
             "id": 2,
-            "order": 1,
             "text": {
-                "de": {"title": "t3", "desc": "d3"},
-                "en": {"title": "t4", "desc": "d4"},
-                "fr": {"title": "t5", "desc": "d5"},
+                "1": {"title": "t3", "desc": "d3"},
+                "2": {"title": "t4", "desc": "d4"},
+                "3": {"title": "t5", "desc": "d5"},
             },
             "milestones": [],
         }


### PR DESCRIPTION
- admin frontend
  - languages can be added, deleted
    - use ISO6391 library to get list of possible language codes and translate codes to native names
  - milestonegroups can be added, edited, deleted
  - milestone group images can be uploaded
  - add lib/admin with functions to interact with API
  - add adminStore with milestones
    - also includes lang_id and isLoggedIn temporarily, probably these should be refactored into main site
- backend
  - add Language model
    - use this id instead of 2-character string to identify language
    - use `(group_id,lang_id)` as primary key for MilestoneGroupText, remove separate primary key
    - add endpoints to get, create and delete languages
